### PR TITLE
Switch to rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/euank/snailquote"
 readme = "README.md"
 keywords = ["quote", "escape", "shell-escape", "uenscape"]
 license = "GPL-3.0-only"
+edition = "2018"
 
 [dependencies]
 unicode_categories = "0.1.1"


### PR DESCRIPTION
No code-changes are needed for this change it turns out.