### PR TITLE
 Fix escaping spaces and special backslash escapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/euank/snailquote.svg?branch=master)](https://travis-ci.org/euank/snailquote)
 
+[![Docs](https://docs.rs/snailquote/badge.svg)](https://docs.rs/snailquote)
+
 This library provides functions to escape and unescape strings.
 
 It escapes them in a roughly 'sh' compatible way (e.g. double quotes supporting


### PR DESCRIPTION
Prior to this, all things that needed to be escaped other than single
and double quotes were escaped with full `\u` syntax.

My original intent was for things that have backslash-escapes (e.g.
newlines) to use their simpler backslash escape instead.

Unfortunately, neither the code nor the tests expressed that intent
correctly.

This changes 'escape' to operate in that manner.

Specifically the following two examples demonstrate this improvement best:

Before:
```
escape("string with spaces") => "string with spaces"
escape("string \t with \t tabs") => "string \u{09} with \u{09} tabs"
```

After:
```
escape("string with spaces") => 'string with spaces'
escape("string \t with \t tabs") => "string \t with \t tabs"
```