### PR TITLE
Remove older rust from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ branches:
   - master
   - dev
 rust:
-  # 1.24.1 is temporarily necessary for building because this version of rustc
-  # is what Pop!_OS currently uses because of Ubuntu 18.04 compatiblity, as some
-  # distros do not update rust as often to meet the periodic breaking changes
-  - 1.24.1
   - stable
   - nightly
 


### PR DESCRIPTION
Currently, that version fails due to dependencies which use newer
features.

If a user of this crate wants to use it on an older rust version,
they'll have to grab a version older than this commit and deal with
finding working versions of dependencies as well.