### PR TITLE
Add error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 unicode_categories = "0.1.1"
+thiserror = "1.0"
 
 [dev-dependencies]
 quickcheck = "0.6"


### PR DESCRIPTION
This PR adds error type instead of `String`.
The new error type has original error messages and compatibility with `std::error::Error`.