### PR TITLE
Make it so escaped ascii text round trips through shell quoting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ thiserror = "1.0"
 [dev-dependencies]
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
+
+[features]
+# This feature enables executing shell commands as part of tests. It's turned
+# off by default.
+unsafe_tests = []
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ unicode_categories = "0.1.1"
 thiserror = "1.0"
 
 [dev-dependencies]
-quickcheck = "0.6"
+quickcheck = "0.9"
+quickcheck_macros = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
-#[macro_use]
 extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
 extern crate unicode_categories;
 
 use std::borrow::Cow;
@@ -424,10 +427,9 @@ mod test {
         }
     }
 
-    quickcheck! {
-        fn round_trips(s: String) -> bool {
-            s == unescape(&escape(&s)).unwrap()
-        }
+    #[quickcheck]
+    fn round_trips(s: String) -> bool {
+        s == unescape(&escape(&s)).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
This adds a quickcheck test that runs effectively `printf "%s" escape(s)` for quick-check generated strings.

I fixed all the failures (things like `.?` escaping to `.?` before, not `'.?'`, even though `?` is a glob pattern in sh. Cool huh?), so I think this leaves us in a safer place for anyone that does use this to try and readably escape things before passing them to shells.

I'm still not sure it's a good idea to do that nor to advertise that this code safely does so, but maybe it's overall a good idea?