### PR TITLE
Improve interoperability of public error types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ fn escape_character(c: char) -> String {
 }
 
 /// Error type of [unescape](unescape).
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UnescapeError {
     #[error("invalid escape {escape} at {index} in {string}")]
     InvalidEscape {
@@ -155,7 +155,7 @@ pub enum UnescapeError {
 }
 
 /// Source error type of [UnescapeError::InvalidUnicode](UnescapeError::InvalidUnicode).
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ParseUnicodeError {
     #[error("expected '{{' character in unicode escape")]
     BraceNotFound,


### PR DESCRIPTION
Specifically [C-COMMON-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits) on the `thiserror` types.

| trait |  | reason |
|:-----|:----|:----|
| Copy | :x: | 64 bytes is a bit large to implement `Copy`
| Clone | :green_circle: | There is no reason _not_ to implement `Clone`
| Eq | :green_circle: |  Already had `PartialEq`, `Eq` seems fine 
| PartialEq | :green_square:   | Existing
| Ord | :x:  | Not ordered
| PartialOrd | :x: | Not ordered
| Hash | :x: | `core::num::error::ParseIntError` doesn't implement `Hash`
| Debug | :green_square: | Existing
| Display | :x: | `thiserror` handles this.
| Default | :x: | Would require treating specific errors as the "default". Seems inappropriate
